### PR TITLE
Allow prefix in config file

### DIFF
--- a/config_example.yaml
+++ b/config_example.yaml
@@ -1,3 +1,6 @@
+prefix:
+  "analysis_name"
+
 genome:
     /path/to/database/genome.fa.gz
 


### PR DESCRIPTION
This allows users to run multiple analyses from the folder in which the Snakefile is located and the results from each will be put in different folder. They can also use the prefix to use another disk for storing the results with `prefix='/mnt/different_folder'`.