### PR TITLE
Phred to probabilities

### DIFF
--- a/methplotlib/methplotlib.py
+++ b/methplotlib/methplotlib.py
@@ -16,6 +16,11 @@ def main():
     for window in windows:
         logging.info("Processing {}".format(window.string))
         meth_data = get_data(args.methylation, args.names, window, args.smooth)
+        if args.store:
+            import pickle
+            pickle.dump(
+                obj=meth_data,
+                file=open("methplotlib-data-{}.pickle".format(window.string), 'wb'))
         logging.info("Collected methylation data for {} datasets".format(len(meth_data)))
         qc_plots(meth_data, window, qcpath=args.qcfile, outpath=args.outfile)
         logging.info("Created QC plots")

--- a/methplotlib/plots.py
+++ b/methplotlib/plots.py
@@ -325,7 +325,8 @@ def make_per_position_phred_scatter(read_table, dotsize=4):
                                   colorscale='Reds',
                                   colorbar=dict(title="Modification probability",
                                                 titleside="right",
-                                                tickvals=[0, read_table['quality'].max()],
+                                                tickvals=[read_table['quality'].min(),
+                                                          read_table['quality'].max()],
                                                 ticktext=["Likely <br> unmodified",
                                                           "Likely <br> modified"],
                                                 ticks="outside")

--- a/methplotlib/utils.py
+++ b/methplotlib/utils.py
@@ -1,4 +1,4 @@
-from argparse import ArgumentParser
+from argparse import ArgumentParser, SUPPRESS
 import sys
 from math import ceil
 from methplotlib.version import __version__
@@ -101,7 +101,9 @@ def get_args():
                              "default is qc_report_methylation_browser_{chr}_{start}_{end}.html. "
                              "Use {region} as a shorthand for {chr}_{start}_{end} in the filename. "
                              "Missing paths will be created.")
-
+    parser.add_argument("--store",
+                        help=SUPPRESS,
+                        action="store_true")
     args = parser.parse_args()
     if not args.example and not len(args.names) == len(args.methylation):
         sys.exit("INPUT ERROR: Expecting the same number of names as datasets!")


### PR DESCRIPTION
This PR changes Phred scale quality scores from the ont cram format to floating point probabilities.

Also, a hidden --store argument is added to create a pickle file of the list of Methylation class data objects for debugging purposes.